### PR TITLE
bugfix/variable tokens eval

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,17 @@
 {
   "name": "rest-book",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "6.2.0",
+      "name": "rest-book",
+      "version": "6.2.1",
       "hasInstallScript": true,
       "dependencies": {
         "-": "0.0.1",
         "@types/react": "^17.0.3",
+        "jsonpath-plus": "^7.0.0",
         "lodash": "^4.17.21",
         "preact": "^10.5.13",
         "save-dev": "0.0.1-security",
@@ -2718,6 +2720,14 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.0.0.tgz",
+      "integrity": "sha512-MH4UnrWrU1hJGVEyEyjvYgONkzNTO6Yol0nq18EMnUQ/ZC5cTuJheirXXIwu1b9mZ6t3XL0P79gPsu+zlTnDIQ==",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/keytar": {
@@ -7279,6 +7289,11 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "jsonpath-plus": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.0.0.tgz",
+      "integrity": "sha512-MH4UnrWrU1hJGVEyEyjvYgONkzNTO6Yol0nq18EMnUQ/ZC5cTuJheirXXIwu1b9mZ6t3XL0P79gPsu+zlTnDIQ=="
     },
     "keytar": {
       "version": "7.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@types/node": "^12.20.10",
         "@types/user-home": "^2.0.0",
         "@types/uuid": "^8.3.0",
+        "@types/vscode": "^1.69.1",
         "@types/vscode-notebook-renderer": "^1.57.8",
         "@typescript-eslint/eslint-plugin": "^4.18.0",
         "@typescript-eslint/parser": "^4.18.0",
@@ -290,6 +291,12 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
       "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
+      "dev": true
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.69.1",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.69.1.tgz",
+      "integrity": "sha512-YZ77g3u9S9Xw3dwAgRgNAwnKNS3nPlhSu3XKOIYQzCcItUrZovfJUlf/29wjON2VZvHGuYQnhKuJUP15ccpVIQ==",
       "dev": true
     },
     "node_modules/@types/vscode-notebook-renderer": {
@@ -5396,6 +5403,12 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
       "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
+      "dev": true
+    },
+    "@types/vscode": {
+      "version": "1.69.1",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.69.1.tgz",
+      "integrity": "sha512-YZ77g3u9S9Xw3dwAgRgNAwnKNS3nPlhSu3XKOIYQzCcItUrZovfJUlf/29wjON2VZvHGuYQnhKuJUP15ccpVIQ==",
       "dev": true
     },
     "@types/vscode-notebook-renderer": {

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
   "dependencies": {
     "-": "0.0.1",
     "@types/react": "^17.0.3",
+    "jsonpath-plus": "^7.0.0",
     "lodash": "^4.17.21",
     "preact": "^10.5.13",
     "save-dev": "0.0.1-security",

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "@types/node": "^12.20.10",
     "@types/user-home": "^2.0.0",
     "@types/uuid": "^8.3.0",
+    "@types/vscode": "^1.69.1",
     "@types/vscode-notebook-renderer": "^1.57.8",
     "@typescript-eslint/eslint-plugin": "^4.18.0",
     "@typescript-eslint/parser": "^4.18.0",

--- a/src/common/cache.ts
+++ b/src/common/cache.ts
@@ -1,7 +1,8 @@
 import { ResponseParser } from './response';
 import { RequestParser } from './request';
 import { SECRETS, hasNoSecrets } from './secrets';
-var stringify = require('json-stringify-safe');
+
+import { JSONPath } from 'jsonpath-plus';
 
 export var variableCache: { [key: string]: ResponseParser | any } = {};
 export var baseUrlCache: Set<string> = new Set();
@@ -45,53 +46,14 @@ export function addToCache(name: string, value: any) {
 }
 
 export function attemptToLoadVariable(text: string): any | undefined {
-    let declaration = _createVariableDeclarationsFromCache();
-    const tokens = text.split('.');
-    let toResolve = ` ${tokens[0]}`;
 
-    for(let i = 1; i < tokens.length; i++) {
-        if(tokens[i].includes('-') || tokens[i].includes(' ')) {
-            toResolve += `["${tokens[i]}"]`;
-        } else {
-            toResolve += `.${tokens[i]}`;
-        }
-    }
+    let data = JSONPath(
+        {
+            json: variableCache,
+            path: `$.${text}`,
+            wrap: false
+        });
+    
+    return data ?? undefined;
 
-    try {
-        return eval(declaration + toResolve);
-    } catch {
-        return undefined;
-    }
-}
-
-export function attemptToLoadVariableInObject(body: any) {
-    _attemptToLoadVariableInObjectHelper(body);
-}
-
-function _attemptToLoadVariableInObjectHelper(obj: any) {
-    for(let key of Object.keys(obj)) {
-        if(typeof obj[key] === 'object') {
-            _attemptToLoadVariableInObjectHelper(obj[key]);
-        }
-
-        let loadedVariable = attemptToLoadVariable(obj[key]);
-        if(loadedVariable) { obj[key] = loadedVariable; }
-    }
-}
-
-function _createVariableDeclarationsFromCache(): string {
-    let ret = '';
-
-    for(let varName of Object.keys(variableCache)) {
-        if(variableCache[varName] instanceof ResponseParser) {
-            ret += `let ${varName} = ${stringify(variableCache[varName].renderer())}; `;
-        } else {
-            ret += `let ${varName} = ${stringify(variableCache[varName])}; `;
-        }
-        
-    }
-
-    if(!hasNoSecrets()) { ret += `let SECRETS = ${stringify(SECRETS)}; `; }
-
-    return ret;
 }

--- a/src/common/response.ts
+++ b/src/common/response.ts
@@ -1,6 +1,7 @@
 import { logDebug } from './common';
 import { ResponseHeaderField } from './httpConstants';
 import { RequestParser } from './request';
+import { VariableParser } from './variableParser';
 import * as secrets from './secrets';
 
 export interface ResponseRendererElements {
@@ -13,7 +14,7 @@ export interface ResponseRendererElements {
 }
 
 export class ResponseParser {
-    private status: number| undefined;
+    private status: number | undefined;
     private statusText: string | undefined;
     private headers: any | undefined;
     private config: any | undefined;
@@ -28,7 +29,7 @@ export class ResponseParser {
 
         let res = response;
 
-        if(response.response && response.status === undefined) {
+        if (response.response && response.status === undefined) {
             res = response.response;
         }
 
@@ -39,7 +40,7 @@ export class ResponseParser {
             // cyclical reference so we need to cherry pick fields
             this.headers = {};
 
-            for(const field of Object.values(ResponseHeaderField)) {
+            for (const field of Object.values(ResponseHeaderField)) {
                 this.headers[field] = res.headers[field.toLowerCase()];
             }
 
@@ -50,14 +51,14 @@ export class ResponseParser {
                 headers: res.config.headers
             };
 
-            
+
             delete request.method;
             delete request.baseURL;
             delete request.url;
 
             this.request = {
                 method: res.request.method,
-                httpVersion:  res.request.res.httpVersion,
+                httpVersion: res.request.res.httpVersion,
                 responseUrl: res.request.res.responseUrl
             };
 
@@ -103,38 +104,39 @@ export class ResponseParser {
 
     private _cleanForSecrets() {
         try {
+            const variableParser = VariableParser.instance;
             // only need to clean config and request
-            if(this.request.responseUrl && this.reqParser.wasReplacedBySecret(this.request.responseUrl)) {
+            if (this.request.responseUrl && variableParser.wasReplacedBySecret(this.request.responseUrl)) {
                 this.request.responseUrl = secrets.cleanForSecrets(this.request.responseUrl);
             }
 
-            if(this.request.data && typeof this.request.data === 'string' && this.reqParser.wasReplacedBySecret(this.request.data)) {
+            if (this.request.data && typeof this.request.data === 'string' && variableParser.wasReplacedBySecret(this.request.data)) {
                 this.request.data = secrets.cleanForSecrets(this.request.data);
             }
 
-            if(this.request.headers && typeof this.request.headers === 'object') {
-                for(let key of Object.keys(this.request.headers)) {
-                    if(this.reqParser.wasReplacedBySecret(this.request.headers[key])) {
+            if (this.request.headers && typeof this.request.headers === 'object') {
+                for (let key of Object.keys(this.request.headers)) {
+                    if (variableParser.wasReplacedBySecret(this.request.headers[key])) {
                         this.request.headers[key] = secrets.cleanForSecrets(this.request.headers[key]);
                     }
                 }
             }
 
-            if(this.request.params && typeof this.request.params === 'object') {
-                for(let key of Object.keys(this.request.params)) {
-                    if(this.reqParser.wasReplacedBySecret(this.request.params[key])) {
+            if (this.request.params && typeof this.request.params === 'object') {
+                for (let key of Object.keys(this.request.params)) {
+                    if (variableParser.wasReplacedBySecret(this.request.params[key])) {
                         this.request.params[key] = secrets.cleanForSecrets(this.request.params[key]);
                     }
                 }
             }
 
-            if(this.config.headers && typeof this.config.headers === 'object') {
-                for(let key of Object.keys(this.config.headers)) {
-                    if(this.reqParser.wasReplacedBySecret(this.config.headers[key])) {
+            if (this.config.headers && typeof this.config.headers === 'object') {
+                for (let key of Object.keys(this.config.headers)) {
+                    if (variableParser.wasReplacedBySecret(this.config.headers[key])) {
                         this.config.headers[key] = secrets.cleanForSecrets(this.config.headers[key]);
                     }
                 }
-            } else if(this.config.headers && typeof this.config.headers === 'string' && this.reqParser.wasReplacedBySecret(this.config.headers)) {
+            } else if (this.config.headers && typeof this.config.headers === 'string' && variableParser.wasReplacedBySecret(this.config.headers)) {
                 this.config.headers = secrets.cleanForSecrets(this.config.headers);
             }
         } catch (e) {

--- a/src/common/tsconfig.json
+++ b/src/common/tsconfig.json
@@ -3,6 +3,9 @@
 	"compilerOptions": {
 		"composite": true,
 		"rootDir": ".",
-		"outDir": "../../out/common"
+		"outDir": "../../out/common",
+		"lib": [
+			"es2020.string"
+		]
 	}
 }

--- a/src/common/variableParser.ts
+++ b/src/common/variableParser.ts
@@ -1,0 +1,108 @@
+var stringify = require('json-stringify-safe');
+import * as cache from './cache';
+
+export interface IVariableResolveResult {
+    value: any;
+    hasResolved: boolean;
+}
+
+export class VariableParser {
+    public readonly curlyBracketsVarMatchExp = /(?:\{\{)(SECRETS:)?([A-Za-z0-9._\-\[\]]*)(?:\}\})/ig;
+
+    public readonly dollarSignVarMatchExp = /\$[A-Za-z0-9.-\[\]]*/gi;
+
+    private static _instance: VariableParser;
+
+    public static get instance(): VariableParser {
+        return this._instance ?? (this._instance = new VariableParser());
+    }
+
+    constructor() { }
+
+    public attemptToLoadVariable(text: string, valuesReplacedBySecrets: string[]): IVariableResolveResult {
+
+        const groups = Array.from(text.matchAll(this.curlyBracketsVarMatchExp));
+
+        let resolvedVariableValue = null;
+        if (groups.length > 0) {
+            resolvedVariableValue = this._attemptToLoadVariableFromRegex(text, groups, valuesReplacedBySecrets);
+        } else {
+            resolvedVariableValue = this._attemptToLoadVariableFromDollarToken(text, valuesReplacedBySecrets);
+        }
+
+        return {
+            value: resolvedVariableValue,
+            hasResolved: resolvedVariableValue !== text
+        };
+    }
+
+    private _attemptToLoadVariableFromRegex(text: string, groups: RegExpMatchArray[], valuesReplacedBySecrets: string[]): string {
+        for (const group of groups) {
+            if (group.length !== 3) {
+                console.log("Unable to process the extracted possible variable: ", group);
+                continue;
+            }
+
+            const possibleVariable = group[2];
+            const loadedFromVariable = cache.attemptToLoadVariable(possibleVariable);
+
+            if (loadedFromVariable) {
+                try {
+                    if (typeof loadedFromVariable !== 'string') {
+                        return text.replace(group[0], stringify(loadedFromVariable));
+                    }
+
+                    if (group[1]?.toUpperCase() === 'SECRETS:') {
+                        valuesReplacedBySecrets.push(loadedFromVariable);
+                    }
+                    return text.replace(group[0], loadedFromVariable);
+                }
+                catch (e) {
+                    console.error(e);
+                }
+            }
+        }
+
+        return text;
+    }
+
+    private _attemptToLoadVariableFromDollarToken(text: string, valuesReplacedBySecrets: string[]): string {
+        const indexOfDollarSign = text.indexOf('$');
+        if (indexOfDollarSign === -1) {
+            return text;
+        }
+
+        const beforeVariable = text.substring(0, indexOfDollarSign);
+
+        const indexOfEndOfPossibleVariable = this._getEndOfWordIndex(text, indexOfDollarSign) + 1;
+        const possibleVariable = text.substring(indexOfDollarSign + 1, indexOfEndOfPossibleVariable);
+        const loadedFromVariable = cache.attemptToLoadVariable(possibleVariable);
+        if (loadedFromVariable) {
+            if (typeof loadedFromVariable !== 'string') {
+                return beforeVariable + stringify(loadedFromVariable);
+            }
+
+            if (possibleVariable.startsWith('SECRETS')) {
+                valuesReplacedBySecrets.push(loadedFromVariable);
+            }
+            return beforeVariable + loadedFromVariable;
+        }
+
+        return text;
+    }
+
+    private _getEndOfWordIndex(text: string, startingIndex?: number): number {
+        let indexOfSpace = text.indexOf(' ', startingIndex ?? 0);
+        let indexOfComma = text.indexOf(',', startingIndex ?? 0);
+        let indexOfSemicolon = text.indexOf(';', startingIndex ?? 0);
+        let indexOfEnd = text.length - 1;
+
+        let values: number[] = [];
+
+        if (indexOfSpace !== -1) { values.push(indexOfSpace); }
+        if (indexOfComma !== -1) { values.push(indexOfComma); }
+        if (indexOfSemicolon !== -1) { values.push(indexOfSemicolon); }
+
+        return Math.min(...values, indexOfEnd);
+    }
+}

--- a/src/extension/languageProvider.ts
+++ b/src/extension/languageProvider.ts
@@ -116,15 +116,14 @@ export class VariableHoverProvider implements vscode.HoverProvider {
 
         const word = document.getText(range);
 
-        // FIXME: pass a valid secrets array
-        const variableResolveResult = VariableParser.instance.attemptToLoadVariable(word, []);
+        const variableResolveResult = VariableParser.instance.attemptToLoadVariable(word);
 
         let hoverContent = null;
         if (!variableResolveResult.hasResolved) {
-            hoverContent = new vscode.Hover(
-                new vscode.MarkdownString(
-                    `*Couldn't find a variable named* ${word}. Ensure the request declaring it has been sent or that the path is valid.`),
-                range);
+            let msgString = new vscode.MarkdownString(
+                `Couldn't find a variable named ${word}.<br/>Ensure the request declaring it has been sent or that the path is valid.`);
+            msgString.supportHtml = true;
+            hoverContent = new vscode.Hover(msgString, range);
         } else {
             hoverContent = new vscode.Hover(
                 new vscode.MarkdownString(`*Variable* ${word}: ${variableResolveResult.value}`),
@@ -156,8 +155,7 @@ export class VariableCompletionItemProvider implements vscode.CompletionItemProv
 
         varName = varName.substr(1, varName.length - 2);
 
-        // FIXME: pass a valid secrets array
-        let matchingData = VariableParser.instance.attemptToLoadVariable(varName, []);
+        let matchingData = VariableParser.instance.attemptToLoadVariable(varName);
 
         if (matchingData && typeof matchingData === 'object') {
             for (let key of Object.keys(matchingData)) {

--- a/src/extension/languageProvider.ts
+++ b/src/extension/languageProvider.ts
@@ -1,9 +1,11 @@
 import * as vscode from 'vscode';
 import { DEBUG_MODE, NAME } from '../common/common';
-import { getVariableNames, getBaseUrls, attemptToLoadVariable } from '../common/cache';
+import { getVariableNames, getBaseUrls } from '../common/cache';
+import { VariableParser } from '../common/variableParser';
 import { Method, MIMEType, RequestHeaderField } from '../common/httpConstants';
 
 const selector: vscode.DocumentSelector = { language: NAME };
+
 export class KeywordCompletionItemProvider implements vscode.CompletionItemProvider {
     static readonly triggerCharacters = [];
 
@@ -12,14 +14,14 @@ export class KeywordCompletionItemProvider implements vscode.CompletionItemProvi
 
         let autocompleteMethod: Boolean = position.line === 0 ? true : false;
 
-        for(const field of Object.values(Method)) {
-            if(document.lineAt(position).text.includes(field)) {
+        for (const field of Object.values(Method)) {
+            if (document.lineAt(position).text.includes(field)) {
                 autocompleteMethod = false;
             }
         }
 
-        if(autocompleteMethod) {
-            for(const field of Object.values(Method)) {
+        if (autocompleteMethod) {
+            for (const field of Object.values(Method)) {
                 result.push({
                     label: field,
                     insertText: `${field} `,
@@ -29,8 +31,8 @@ export class KeywordCompletionItemProvider implements vscode.CompletionItemProvi
             }
         }
 
-        if(position.line !== 0) {
-            for(const field of Object.values(RequestHeaderField)) {
+        if (position.line !== 0) {
+            for (const field of Object.values(RequestHeaderField)) {
                 result.push({
                     label: field,
                     insertText: `${field}: `,
@@ -40,7 +42,7 @@ export class KeywordCompletionItemProvider implements vscode.CompletionItemProvi
             }
         }
 
-        for(const url of getBaseUrls()) {
+        for (const url of getBaseUrls()) {
             result.push({
                 label: url,
                 kind: vscode.CompletionItemKind.Keyword
@@ -53,8 +55,8 @@ export class KeywordCompletionItemProvider implements vscode.CompletionItemProvi
                 insertText: `${str} `,
                 kind: vscode.CompletionItemKind.Keyword
             });
-        })
-        
+        });
+
         return result;
     }
 }
@@ -65,16 +67,16 @@ export class HeaderCompletionItemProvider implements vscode.CompletionItemProvid
     provideCompletionItems(_document: vscode.TextDocument, position: vscode.Position, _token: vscode.CancellationToken, _context: vscode.CompletionContext): vscode.ProviderResult<vscode.CompletionItem[] | vscode.CompletionList<vscode.CompletionItem>> {
         const result: vscode.CompletionItem[] = [];
 
-        if(position.line === 0) { return result; }
+        if (position.line === 0) { return result; }
 
-        for(const field of Object.values(MIMEType)) {
+        for (const field of Object.values(MIMEType)) {
             result.push({
                 label: field,
                 detail: 'HTTP MIME type',
                 kind: vscode.CompletionItemKind.EnumMember
             });
         }
-        
+
         return result;
     }
 }
@@ -85,42 +87,87 @@ export class CacheVariableCompletionItemProvider implements vscode.CompletionIte
     provideCompletionItems(_document: vscode.TextDocument, _position: vscode.Position, _token: vscode.CancellationToken, _context: vscode.CompletionContext): vscode.ProviderResult<vscode.CompletionItem[] | vscode.CompletionList<vscode.CompletionItem>> {
         const result: vscode.CompletionItem[] = [];
 
-        for(const variable of getVariableNames()) {
+        for (const variable of getVariableNames()) {
             result.push({
                 label: variable,
                 kind: vscode.CompletionItemKind.Variable
             });
         }
-        
+
         return result;
     }
+}
+
+export class VariableHoverProvider implements vscode.HoverProvider {
+    provideHover(
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        token: vscode.CancellationToken): vscode.ProviderResult<vscode.Hover> {
+        
+        console.debug("Hover called:", document, position, token);
+
+        let range =
+            document.getWordRangeAtPosition(position, VariableParser.instance.curlyBracketsVarMatchExp) ??
+            document.getWordRangeAtPosition(position, VariableParser.instance.dollarSignVarMatchExp);
+
+        if (!range) {
+            return;
+        }
+
+        const word = document.getText(range);
+
+        // FIXME: pass a valid secrets array
+        const variableResolveResult = VariableParser.instance.attemptToLoadVariable(word, []);
+
+        let hoverContent = null;
+        if (!variableResolveResult.hasResolved) {
+            hoverContent = new vscode.Hover(
+                new vscode.MarkdownString(
+                    `*Couldn't find a variable named* ${word}. Ensure the request declaring it has been sent or that the path is valid.`),
+                range);
+        } else {
+            hoverContent = new vscode.Hover(
+                new vscode.MarkdownString(`*Variable* ${word}: ${variableResolveResult.value}`),
+                range);
+        }
+        return hoverContent;
+    }
+
 }
 
 export class VariableCompletionItemProvider implements vscode.CompletionItemProvider {
     static readonly triggerCharacters = ['.'];
 
-    provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, _token: vscode.CancellationToken, _context: vscode.CompletionContext): vscode.ProviderResult<vscode.CompletionItem[] | vscode.CompletionList<vscode.CompletionItem>> {
+    provideCompletionItems(
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        _token: vscode.CancellationToken,
+        _context: vscode.CompletionContext): vscode.ProviderResult<vscode.CompletionItem[] | vscode.CompletionList<vscode.CompletionItem>> {
         const result: vscode.CompletionItem[] = [];
 
         let text = document.lineAt(position.line).text.substring(0, position.character);
-        let startingIndex =  Math.max(text.lastIndexOf(' '), text.lastIndexOf('='), text.lastIndexOf('/')) + 1;
+        let startingIndex = Math.max(text.lastIndexOf(' '), text.lastIndexOf('='), text.lastIndexOf('/')) + 1;
         let varName = text.substring(startingIndex).trim();
 
-        if(!varName.startsWith('$')) { return result }
+        const matchesVariable = varName.startsWith('$') || varName.startsWith('{{');
+        if (!matchesVariable) {
+            return result;
+        }
 
         varName = varName.substr(1, varName.length - 2);
 
-        let matchingData = attemptToLoadVariable(varName);
+        // FIXME: pass a valid secrets array
+        let matchingData = VariableParser.instance.attemptToLoadVariable(varName, []);
 
-        if(matchingData && typeof matchingData === 'object') {
-            for(let key of Object.keys(matchingData)) {
+        if (matchingData && typeof matchingData === 'object') {
+            for (let key of Object.keys(matchingData)) {
                 result.push({
                     label: key,
                     kind: vscode.CompletionItemKind.Variable
                 });
             }
         }
-        
+
         return result;
     }
 }
@@ -130,9 +177,20 @@ export function registerLanguageProvider(): vscode.Disposable {
     const disposables: vscode.Disposable[] = [];
 
     // TODO add hover provider or definition provider
-    disposables.push(vscode.languages.registerCompletionItemProvider(selector, new KeywordCompletionItemProvider(), ...KeywordCompletionItemProvider.triggerCharacters));
-    disposables.push(vscode.languages.registerCompletionItemProvider(selector, new HeaderCompletionItemProvider(), ...HeaderCompletionItemProvider.triggerCharacters));
-    disposables.push(vscode.languages.registerCompletionItemProvider(selector, new CacheVariableCompletionItemProvider(), ...CacheVariableCompletionItemProvider.triggerCharacters));
-    disposables.push(vscode.languages.registerCompletionItemProvider(selector, new VariableCompletionItemProvider(), ...VariableCompletionItemProvider.triggerCharacters));
+    disposables.push(
+        vscode.languages.registerCompletionItemProvider(
+            selector, new KeywordCompletionItemProvider(), ...KeywordCompletionItemProvider.triggerCharacters));
+    disposables.push(
+        vscode.languages.registerCompletionItemProvider(
+            selector, new HeaderCompletionItemProvider(), ...HeaderCompletionItemProvider.triggerCharacters));
+    disposables.push(
+        vscode.languages.registerCompletionItemProvider(
+            selector, new CacheVariableCompletionItemProvider(), ...CacheVariableCompletionItemProvider.triggerCharacters));
+    disposables.push(
+        vscode.languages.registerCompletionItemProvider(
+            selector, new VariableCompletionItemProvider(), ...VariableCompletionItemProvider.triggerCharacters));
+    disposables.push(
+        vscode.languages.registerHoverProvider(selector, new VariableHoverProvider())
+    );
     return vscode.Disposable.from(...disposables);
 }

--- a/src/extension/notebookKernel.ts
+++ b/src/extension/notebookKernel.ts
@@ -61,13 +61,17 @@ export class NotebookKernel {
 
                 execution.end(true, Date.now());
             } catch (e) {
+                const errorMsg = e instanceof Error && e.message || stringify(e, undefined, 4);
                 execution.replaceOutput([
                     new vscode.NotebookCellOutput([
                         vscode.NotebookCellOutputItem.error({ 
                             name: e instanceof Error && e.name || 'error', 
-                            message: e instanceof Error && e.message || stringify(e, undefined, 4)})
+                            message: errorMsg})
                     ])
                 ]);
+                
+                vscode.window.showErrorMessage(
+                    `An error occured while processing the REST Book request: ${errorMsg}`, "OK");
                 execution.end(false, Date.now());
             }
         };
@@ -85,6 +89,7 @@ export class NotebookKernel {
             }
             
         } catch (err) {
+            const errorMsg = err instanceof Error && err.message || stringify(err, undefined, 4);
             execution.replaceOutput([
                 new vscode.NotebookCellOutput([
                     vscode.NotebookCellOutputItem.error({ 
@@ -92,6 +97,9 @@ export class NotebookKernel {
                             message: err instanceof Error && err.message || stringify(err, undefined, 4)})
                 ])
             ]);
+
+            vscode.window.showErrorMessage(
+                `An error occured while processing the REST Book request: ${errorMsg}`, "OK");
             execution.end(false, Date.now());
             return;
         }

--- a/syntaxes/rest-book.tmGrammar.json
+++ b/syntaxes/rest-book.tmGrammar.json
@@ -35,7 +35,7 @@
         },
         "variable": {
             "name": "variable",
-            "match": "\\$[A-Za-z0-9.-\\[\\]]*"
+            "match": "\\{\\{[A-Za-z0-9._\\-\\[\\]]*\\}\\}"
         },
         "json": {
             "begin": "\\{",

--- a/syntaxes/rest-book.tmGrammar.json
+++ b/syntaxes/rest-book.tmGrammar.json
@@ -11,6 +11,9 @@
             "include": "#variable"
         },
         {
+            "include": "#variableOther"
+        },
+        {
             "include": "#headerkey"
         },
         {
@@ -35,7 +38,11 @@
         },
         "variable": {
             "name": "variable",
-            "match": "\\{\\{[A-Za-z0-9._\\-\\[\\]]*\\}\\}"
+            "match": "(?:\\{\\{)(SECRETS:)?([A-Za-z0-9._\\-\\[\\]]*)(?:\\}\\})"
+        },
+        "variableOther": {
+            "name": "variable.other",
+            "match": "\\$[A-Za-z0-9.-\\[\\]]*"
         },
         "json": {
             "begin": "\\{",


### PR DESCRIPTION
To improve variable evaluations, this change adds support for curly brackets evaluation.
It can be used several times inside the URL, headers or body of a request since it is parsed through regex groups.
Also, an initial Hover over variables will display the variable content if it was already processed.

Some of the caching and variable extraction was moved from the request.ts into a new dedicated class. Since the Hover doesn't have context of the request nor the Notebook cell (only the code document of the cell being hovered), the variable parser is a singleton and so lives through executed requests and the session of the file.
This part can probably be improved.